### PR TITLE
Update draft-ietf-scim-events-04.xml - Unsecures tokens

### DIFF
--- a/draft-ietf-scim-events-04.xml
+++ b/draft-ietf-scim-events-04.xml
@@ -1146,9 +1146,7 @@ Location:
                     <dt>Unsecured</dt>
                     <dd>
                         Per Section 6 <xref target="RFC7519"/>, tokens MAY be generated with <tt>{"alg":"none"}</tt>.
-                        This mode speeds up processing and is best used in DBR scenarios. Unencrypted tokens MUST be
-                        transferred over authenticated TLS layer encryption and SHOULD only be used in a restricted
-                        network environment.
+                        Unsecured tokens SHALL NOT be used.                       
                     </dd>
                     <dt>Signed</dt>
                     <dd>


### PR DESCRIPTION
Updated language to prevent the use of unencrypted, unsigned tokens in this profile.  The concept of "inside" and "outside" networks is no longer sufficient to consider whether transmitting over a TLS-only protocol is sufficient for securing such information.

Supporting such tokens is likely to lead to implementations that leak sensitive information and / or man in the middle interception/modification of SETs.