### PR TITLE
Removed authMethod/pwdReset from IANA registry

### DIFF
--- a/draft-ietf-scim-events-04.xml
+++ b/draft-ietf-scim-events-04.xml
@@ -1509,20 +1509,6 @@ Location:
                         </td>
                     </tr>
                     <tr>
-                        <td align="left">urn:ietf:params:SCIM:event:sig:authMethod</td>
-                        <td align="left">New authentication method added</td>
-                        <td align="left">
-                            <xref target="authMethod" format="default"/>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td align="left">urn:ietf:params:SCIM:event:sig:pwdReset</td>
-                        <td align="left">Password Reset Event</td>
-                        <td align="left">
-                            <xref target="sigPassReset" format="default"/>
-                        </td>
-                    </tr>
-                    <tr>
                         <td align="left">urn:ietf:params:SCIM:event:misc:asyncResp</td>
                         <td align="left">Async Request Completion</td>
                         <td align="left">


### PR DESCRIPTION
As noted in #19 these events are duplicative of RISC/CAEP events and should be removed.